### PR TITLE
use standard way of getting download folder

### DIFF
--- a/tailscale-status@maxgallup.github.com/extension.js
+++ b/tailscale-status@maxgallup.github.com/extension.js
@@ -46,7 +46,8 @@ let shieldItem;
 let acceptRoutesItem;
 let allowLanItem;
 let statusSwitchItem;
-let downloads_path = "/home/" + Me.path.split("/")[2] + "/Downloads";
+let downloads_path = GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_DOWNLOAD);
+
 
 function extractNodeInfo(json) {
     nodes = [];
@@ -289,7 +290,7 @@ function cmdTailscaleRecFiles() {
                     Main.notify('Saved files to ' + downloads_path);
                 } else {
                     Main.notify('Unable to receive files to ' + downloads_path, 'check logs with journalctl -f -o cat /usr/bin/gnome-shell');
-                    log("failed to accept files to ~/Downloads/")
+                    log("failed to accept files to "+downloads_path)
                 }
             } catch (e) {
                 logError(e);

--- a/tailscale-status@maxgallup.github.com/extension.js
+++ b/tailscale-status@maxgallup.github.com/extension.js
@@ -48,7 +48,6 @@ let allowLanItem;
 let statusSwitchItem;
 let downloads_path = GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_DOWNLOAD);
 
-
 function extractNodeInfo(json) {
     nodes = [];
 

--- a/tailscale-status@maxgallup.github.com/extension.js
+++ b/tailscale-status@maxgallup.github.com/extension.js
@@ -289,7 +289,7 @@ function cmdTailscaleRecFiles() {
                     Main.notify('Saved files to ' + downloads_path);
                 } else {
                     Main.notify('Unable to receive files to ' + downloads_path, 'check logs with journalctl -f -o cat /usr/bin/gnome-shell');
-                    log("failed to accept files to "+downloads_path)
+                    log("failed to accept files to " + downloads_path)
                 }
             } catch (e) {
                 logError(e);


### PR DESCRIPTION
```
"/home/" + Me.path.split("/")[2] + "/Downloads"
```
This does not always work, in Fedora silverblue, Me.path is /var/home/username/  so it becomes /home/home/Downloads (see screenshot)

![image](https://user-images.githubusercontent.com/1192563/181866083-3aa6e21f-8924-4a78-88b0-e02717ce001e.png)

Also "Downloads" is not standard as people using a different language or changed the download folder location using xdg-user-dirs  won't be using ~/Downloads
