### PR TITLE
Use node name from DNSName

### DIFF
--- a/tailscale-status@maxgallup.github.com/extension.js
+++ b/tailscale-status@maxgallup.github.com/extension.js
@@ -58,7 +58,7 @@ function extractNodeInfo(json) {
 
     var me = json.Self;
     nodes.push(new TailscaleNode(
-        me.HostName,
+        me.DNSName.split(".")[0],
         me.TailscaleIPs[0],
         me.Online,
         me.ExitNodeOption,
@@ -69,7 +69,7 @@ function extractNodeInfo(json) {
     for (let p in json.Peer) {
         var n = json.Peer[p];
         nodes.push(new TailscaleNode(
-            n.HostName,
+            n.DNSName.split(".")[0],
             n.TailscaleIPs[0],
             n.Online,
             n.ExitNodeOption,


### PR DESCRIPTION
I have some nodes that have different DNS names from hostnames. When connecting to a exit node, it cannot connect by hostname but can by IP address or base name (I assume this is the same as the first item in DNSName).
With this change I am able to switch between exit nodes correctly.
