### PR TITLE
Remove unnecessary pkexec on file get (should fix #38?)

### DIFF
--- a/tailscale-status@maxgallup.github.com/extension.js
+++ b/tailscale-status@maxgallup.github.com/extension.js
@@ -422,7 +422,7 @@ function cmdTailscale({args, unprivileged = true, addLoginServer = true}) {
 function cmdTailscaleRecFiles() {
     try {
         let proc = Gio.Subprocess.new(
-            ["pkexec", "tailscale", "file", "get", downloads_path],
+            ["tailscale", "file", "get", downloads_path],
             Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_PIPE
         );
         proc.communicate_utf8_async(null, null, (proc, res) => {


### PR DESCRIPTION
I haven't been able to properly test this, but running the commands manually seems to work fine.
Closes #38 