### PR TITLE
fix: unable to change account

### DIFF
--- a/tailscale-status@maxgallup.github.com/extension.js
+++ b/tailscale-status@maxgallup.github.com/extension.js
@@ -316,7 +316,14 @@ function cmdTailscaleSwitchList(unprivileged  = true) {
                         }
                         let accountItem = new PopupMenu.PopupMenuItem(account)
                         accountItem.connect('activate', () => {
-                            cmdTailscaleSwitch(account)
+                            // find the mail address in the account string
+                            const emailRegex = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/;
+                            const email = account.match(emailRegex);
+                            if (email == null) {
+                                myError("failed to extract email from account string")
+                                return
+                            }
+                            cmdTailscaleSwitch(email[0]);
                         });
                         accountsMenu.menu.addMenuItem(accountItem);
                     });


### PR DESCRIPTION
The account change was not possible with the full account string. Separating the mail address from the string fixed the issue.

I hope this is a helpful fix. Maybe it's better to use the identifier at the start of the string.
