### PR TITLE
Deal with Mullvad exit nodes better

### DIFF
--- a/tailscale-status@maxgallup.github.com/extension.js
+++ b/tailscale-status@maxgallup.github.com/extension.js
@@ -20,13 +20,21 @@ const disabledString = "⚫";
 const ownConnectionString = "💻";
 
 class TailscaleNode {
-    constructor(_name, _address, _online, _offersExit, _usesExit, _isSelf) {
+    /**
+     * @param {boolean} _isMullvadExitNode
+     * @param {string[]} _groupPath - e.g. ["Mullvad", "Norway", "Oslo"]
+     */
+    constructor(_name, _address, _online, _offersExit, _usesExit, _isSelf, _isMullvadExitNode, _groupPath) {
         this.name = _name;
         this.address = _address;
         this.online = _online;
         this.offersExit = _offersExit;
         this.usesExit = _usesExit;
         this.isSelf = _isSelf;
+        /** We probably want to ignore these for anything that's not picking an exit node. */
+        this.isMullvadExitNode = _isMullvadExitNode;
+        /** Currently just used to group the Mullvad exit nodes, but code is structured to take arbitrary groupings. */
+        this.groupPath = _groupPath;
     }
 
     get line() {
@@ -42,7 +50,11 @@ class TailscaleNode {
     }
 }
 
+/** @type {TailscaleNode[]} */
 let nodes = [];
+/** @typedef {{nodes: TailscaleNode[], subTrees: {[k: string]: NodesTree}}} NodesTree */
+/** @type {NodesTree} */
+let nodesTree = { nodes: [], subTrees: {} }
 let accounts = [];
 let currentAccount = "(click Update Accounts List)";
 
@@ -84,6 +96,7 @@ function myError(string) {
 
 function extractNodeInfo(json) {
     nodes = [];
+    nodesTree = { nodes: [], subTrees: {} };
 
     var me = json.Self;
     if (me.TailscaleIPs != null) {
@@ -93,12 +106,26 @@ function extractNodeInfo(json) {
             me.Online,
             me.ExitNodeOption,
             me.ExitNode,
-            true
+            true,
+            false,
+            []
         )
         );
     }
     for (let p in json.Peer) {
         var n = json.Peer[p];
+        let isMullvad = false;
+        let groupPath = [];
+        // We special-case these guys. Tailscale clients sometimes refer to "Location-based exit nodes",
+        // perhaps in future it should be done by nodes with a .Location instead?
+        if (n.Tags?.includes('tag:mullvad-exit-node')) {
+            isMullvad = true;
+            if (n.Location?.Country && n.Location?.City) {
+                groupPath = ["Mullvad", n.Location.Country, n.Location.City];
+            } else {
+                groupPath = ["Mullvad"]
+            }
+        }
         if (n.TailscaleIPs != null) {
             nodes.push(new TailscaleNode(
                 n.DNSName.split(".")[0],
@@ -106,12 +133,26 @@ function extractNodeInfo(json) {
                 n.Online,
                 n.ExitNodeOption,
                 n.ExitNode,
-                false
+                false,
+                isMullvad,
+                groupPath
             ));
         }
 
     }
     nodes.sort(sortNodes)
+
+    for (const n of nodes) {
+        let t = nodesTree;
+        // recurse into / initialize the tree, one level per entry in groupPath
+        for (const p of n.groupPath) {
+            if (!(p in t.subTrees)) {
+                t.subTrees[p] = { nodes: [], subTrees: {} }
+            }
+            t = t.subTrees[p]
+        }
+        t.nodes.push(n);
+    }
 }
 
 function sortNodes(a, b) {
@@ -195,7 +236,7 @@ function setStatus(json) {
             authItem.sensitive = true;
             statusItem.label.text = statusString + "needs login";
             authItem.label.text = "Click to Login"
-            
+
             setAllItems(false);
             nodes = [];
             break;
@@ -233,34 +274,95 @@ function refreshNodesMenu() {
     });
 }
 
+/**
+ * This is a PopupSubMenuMenuItem with some patches to make nested submenus work,
+ * by default they don't work at all.
+ */
+const FixedSubMenuMenuItem = GObject.registerClass(
+class FixedSubMenuMenuItem extends PopupMenu.PopupSubMenuMenuItem {
+    _init(name, rootScroller) {
+        super._init(name);
+        this.rootScroller = rootScroller;
 
+        // Monkey-patch scrolling - we'll leave scrolling to the rootScroller.
+        // Disable scrolling on our own menu's ScrollBox.
+        this.menu._needsScrollbar = () => false;
+        this.menu.actor.set_mouse_scrolling(false);
+    }
+
+    _subMenuOpenStateChanged(menu, open) {
+        super._subMenuOpenStateChanged(menu, open);
+
+        // we've changed the height of a submenu. Gnome doesn't handle this properly,
+        // so we need to go and tell the rootScroller that its height has changed.
+        // Copy-paste from PopupSubMenu.open().
+        {
+            const needsScrollbar = this.rootScroller._needsScrollbar();
+
+            this.rootScroller.actor.vscrollbar_policy = St.PolicyType.ALWAYS;
+
+            if (needsScrollbar)
+                this.rootScroller.actor.add_style_pseudo_class('scrolled');
+            else
+                this.rootScroller.actor.remove_style_pseudo_class('scrolled');
+        }
+
+    }
+}
+);
+
+/**
+ * @param {PopupMenu.PopupMenuBase} menu
+ * @param {NodesTree} t
+ * @param {string} indent
+ * @param {PopupMenu.PopupMenuBase | null} rootScroller
+ *   we need to keep track of the ExitNodes popupmenu so we can fix Gnome's buggy handling of nested
+ *   submenus.
+ */
+function _refreshExitNodesMenu(menu, t, indent = '', rootScroller = null) {
+    let usesExit = false;
+
+    // Add any nodes to this level of the tree
+    for (const node of t.nodes) {
+        if (!node.offersExit) {
+            continue;
+        }
+
+        const item = new PopupMenu.PopupMenuItem(indent+node.name)
+        item.connect('activate', () => {
+            cmdTailscale({ args: ["up", "--exit-node=" + node.address, "--reset"] })
+        });
+        item.setOrnament(node.usesExit ? 1 : 0)
+        menu.addMenuItem(item);
+        usesExit ||= node.usesExit;
+    }
+
+    rootScroller = rootScroller || menu;
+
+    // Add any subtress to this level of the tree
+    for (const [name, st] of Object.entries(t.subTrees)) {
+        const subMenu = new FixedSubMenuMenuItem(indent+name, rootScroller);
+
+        const stUsesExit = _refreshExitNodesMenu(subMenu.menu, st, indent+' ', rootScroller)
+
+        subMenu.setOrnament(stUsesExit ? 1 : 0)
+        menu.addMenuItem(subMenu)
+        usesExit ||= stUsesExit
+    }
+
+    return usesExit
+}
 
 function refreshExitNodesMenu() {
     exitNodeMenu.menu.removeAll();
-    var uses_exit = false;
-    nodes.sort(sortByName);
-    nodes.forEach((node) => {
-        if (node.offersExit) {
-            var item = new PopupMenu.PopupMenuItem(node.name)
-            item.connect('activate', () => {
-                cmdTailscale({ args: ["up", "--exit-node=" + node.address, "--reset"] })
-            });
-            if (node.usesExit) {
-                item.setOrnament(1);
-                exitNodeMenu.menu.addMenuItem(item);
-                uses_exit = true;
-            } else {
-                item.setOrnament(0);
-                exitNodeMenu.menu.addMenuItem(item);
-            }
-        }
-    })
+
+    const usesExit = _refreshExitNodesMenu(exitNodeMenu.menu, nodesTree);
 
     var noneItem = new PopupMenu.PopupMenuItem('None');
     noneItem.connect('activate', () => {
-        cmdTailscale({args: ["up", "--exit-node=", "--reset"] });
+        cmdTailscale({ args: ["up", "--exit-node=", "--reset"] });
     });
-    (uses_exit) ? noneItem.setOrnament(0) : noneItem.setOrnament(1);
+    noneItem.setOrnament(usesExit ? 0 : 1)
     exitNodeMenu.menu.addMenuItem(noneItem, 0);
 }
 
@@ -478,13 +580,18 @@ const TailscalePopup = GObject.registerClass(
                 }
             });
 
-            
+            // monkey-patch to nuke this property - it's buggy, if submenus are in a tree,
+            // then it causes the parent to close when a child is opened, even though the parent
+            // should stay open so you can see the child!
+            this.menu._setOpenedSubMenu = () => {};
+
+
             // ------ MAIN STATUS ITEM ------
             statusItem = new PopupMenu.PopupMenuItem(statusString, { reactive: false });
 
             // ------ AUTH ITEM ------
             authItem = new PopupMenu.PopupMenuItem("Logged in", false);
-            
+
             authItem.connect('activate', () => {
                 cmdTailscaleStatus()
                 if (authUrl.length == 0) {
@@ -540,7 +647,7 @@ const TailscalePopup = GObject.registerClass(
                 }
             })
 
-            
+
             // ------ ACCEPT ROUTES ------
             acceptRoutesItem = new PopupMenu.PopupSwitchMenuItem("Accept Routes", false);
             acceptRoutesItem.connect('activate', () => {
@@ -550,7 +657,7 @@ const TailscalePopup = GObject.registerClass(
                     cmdTailscale({ args: ["up", "--accept-routes=false", "--reset"] });
                 }
             })
-            
+
             // ------ ALLOW DIRECT LAN ACCESS ------
             allowLanItem = new PopupMenu.PopupSwitchMenuItem("Allow Direct Lan Access", false);
             allowLanItem.connect('activate', () => {
@@ -571,13 +678,13 @@ const TailscalePopup = GObject.registerClass(
             receiveFilesItem.connect('activate', () => {
                 cmdTailscaleRecFiles();
             })
-            
+
             // ------ SEND FILES MENU ------
             sendMenu = new PopupMenu.PopupSubMenuMenuItem("Send Files");
-            
+
             // ------ EXIT NODES -------
             exitNodeMenu = new PopupMenu.PopupSubMenuMenuItem("Exit Nodes");
-            
+
             // ------ LOG OUT -------
             logoutButton = new PopupMenu.PopupMenuItem("Log Out");
             logoutButton.connect('activate', () => {
@@ -586,14 +693,14 @@ const TailscalePopup = GObject.registerClass(
                     addLoginServer: false,
                 });
             })
-            
+
             // ------ ABOUT MENU------
             let aboutMenu = new PopupMenu.PopupSubMenuMenuItem("About");
             let healthMenu = new PopupMenu.PopupMenuItem("Health")
             healthMenu.connect('activate', () => {
                 if (health != null) {
                     Main.notify(health.join());
-                    
+
                 } else {
                     Main.notify("null");
                 }
@@ -603,7 +710,7 @@ const TailscalePopup = GObject.registerClass(
             contributeMenu.connect('activate', () => {
                 Util.spawn(['xdg-open', "https://github.com/maxgallup/tailscale-status#contribute"])
             })
-            
+
 
             // Order Matters!
             this.menu.addMenuItem(statusSwitchItem);
@@ -654,4 +761,3 @@ function disable() {
     SETTINGS = null;
     accounts = [];
 }
-

--- a/tailscale-status@maxgallup.github.com/extension.js
+++ b/tailscale-status@maxgallup.github.com/extension.js
@@ -140,7 +140,7 @@ function extractNodeInfo(json) {
         }
 
     }
-    nodes.sort(sortNodes)
+    nodes.sort(combineSort(sortProp('isSelf'), sortProp('online', 'desc'), sortArrProp('groupPath'), sortProp('name')))
 
     for (const n of nodes) {
         let t = nodesTree;
@@ -155,32 +155,48 @@ function extractNodeInfo(json) {
     }
 }
 
-function sortNodes(a, b) {
-    if (a.isSelf == true && b.isSelf == false) {
-        return -1;
-    }
-
-    if (a.online == true && b.online == true) {
-        return 0;
-    } else if (a.online == true && b.online == false) {
-        return -1;
-    } else if (a.online == false && b.online == true) {
-        return 1;
-    } else if (a.online == false && b.online == false) {
-        return 0;
-    }
-}
-
-function sortByName(a, b) {
-    if (a.name > b.name) {
-        return 1;
-    } else if (a.name == b.name) {
-        return 0;
-    } else {
-        return -1;
+function sortArrProp(p) {
+    return function comp(a, b) {
+        const [_aa, _bb] = [a[p] ?? [], b[p] ?? []]
+        for (let i = 0; i < Math.max(_aa.length, _bb.length); i++) {
+            const [_a, _b] = [_aa[i], _bb[i]]
+            if (_a < _b) {
+                return -1;
+            } else if (_b < _a) {
+                return 1;
+            } else {
+                continue;
+            }
+        }
     }
 }
-
+/** @param {'desc' | undefined} desc - descending sort */
+function sortProp(p, desc=undefined) {
+    return function comp(a, b) {
+        if (desc == 'desc') {
+            [b, a] = [a, b];
+        }
+        const [_a, _b] = [a[p], b[p]];
+        if (_a < _b) {
+            return -1;
+        } else if (_b < _a) {
+            return 1;
+        } else {
+            return 0;
+        }
+    }
+}
+function combineSort(...sorters) {
+    return function comp(a, b) {
+        for (const fn of sorters) {
+            const res = fn(a, b);
+            if (res != 0) {
+                return res
+            }
+            // else this sorter considers them equal, try the next one.
+        }
+    }
+}
 
 function getUsername(json) {
     let id = 0

--- a/tailscale-status@maxgallup.github.com/extension.js
+++ b/tailscale-status@maxgallup.github.com/extension.js
@@ -9,6 +9,7 @@ const GObject = imports.gi.GObject;
 const GLib = imports.gi.GLib;
 const Gio = imports.gi.Gio;
 
+
 const PanelMenu = imports.ui.panelMenu;
 const PopupMenu = imports.ui.popupMenu;
 

--- a/tailscale-status@maxgallup.github.com/extension.js
+++ b/tailscale-status@maxgallup.github.com/extension.js
@@ -280,14 +280,18 @@ function setAllItems(b) {
 
 function refreshNodesMenu() {
     nodesMenu.menu.removeAll();
-    nodes.forEach((node) => {
+    for (const node of nodes) {
+        if (node.isMullvadExitNode) {
+            continue;
+        }
+
         let item = new PopupMenu.PopupMenuItem(node.line)
         item.connect('activate', () => {
             St.Clipboard.get_default().set_text(St.ClipboardType.CLIPBOARD, node.address);
             Main.notify("Copied " + node.address + " to clipboard! (" + node.name + ")");
         });
         nodesMenu.menu.addMenuItem(item);
-    });
+    };
 }
 
 /**
@@ -384,15 +388,17 @@ function refreshExitNodesMenu() {
 
 function refreshSendMenu() {
     sendMenu.menu.removeAll();
-    nodes.forEach((node) => {
-        if (node.online && !node.isSelf) {
-            var item = new PopupMenu.PopupMenuItem(node.name)
-            item.connect('activate', () => {
-                sendFiles(node.address);
-            });
-            sendMenu.menu.addMenuItem(item);
+    for (const node of nodes) {
+        if (!node.online || node.isSelf || node.isMullvadExitNode) {
+            continue;
         }
-    })
+
+        var item = new PopupMenu.PopupMenuItem(node.name)
+        item.connect('activate', () => {
+            sendFiles(node.address);
+        });
+        sendMenu.menu.addMenuItem(item);
+    }
 }
 
 function sendFiles(dest) {


### PR DESCRIPTION
Heya, thanks for maintaining this.

As per https://github.com/maxgallup/tailscale-status/issues/46 , the Mullvad Tailscale add-on is a little unwieldy, as it adds a couple of hundred exit nodes to your tailnet.

This PR adds some functionality to make this more ergonomic - Mullvad nodes are stuck in a location-based tree. In addition they are excluded from the Send Files and Send Clipboard lists.

The grouping functionality has been written to be decoupled from Mullvad stuff.

I've used Typescript jsdoc comments in places to try and make my code a bit easier to follow , for both me and my editor - jsdoc is a bit wordy for my tastes but I find it too difficult to track recursion etc without some help from my IDE. I can remove these if you'd rather go without.

The submenu system has a few monkey patches - unfortunately Gnome-Shell has a surprisingly buggy and barebones implementation of menus for something from a 4th-generation desktop environment. OOTB, nested submenus don't work at all.


![Screenshot from 2025-02-17 21-45-20-censored](https://github.com/user-attachments/assets/a86e0759-8724-4ffd-9de5-63f9dbda27e9)
