### PR TITLE
Updated metadata.json with version 48

### DIFF
--- a/tailscale-status@maxgallup.github.com/metadata.json
+++ b/tailscale-status@maxgallup.github.com/metadata.json
@@ -6,7 +6,8 @@
   "shell-version": [
     "45",
     "46",
-    "47"
+    "47",
+    "48"
   ],
   "url": "https://github.com/maxgallup/tailscale-status",
   "uuid": "tailscale-status@maxgallup.github.com",


### PR DESCRIPTION
Modified metadata.json for GNOME 48. Tested and verified that extension runs within GNOME 48.1 (Fedora Workstation 42).

Addresses issue #61.