### PR TITLE
chore: add GNOME 50 support

### DIFF
--- a/tailscale-status@maxgallup.github.com/extension.js
+++ b/tailscale-status@maxgallup.github.com/extension.js
@@ -2,7 +2,6 @@ import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import St from 'gi://St';
 import Clutter from 'gi://Clutter';
 
-import * as ExtensionUtils from 'resource:///org/gnome/shell/misc/extensionUtils.js';
 import * as Util from 'resource:///org/gnome/shell/misc/util.js';
 
 import GObject from 'gi://GObject';

--- a/tailscale-status@maxgallup.github.com/metadata.json
+++ b/tailscale-status@maxgallup.github.com/metadata.json
@@ -3,8 +3,8 @@
   "description": "Manage Tailscale connections and check status from desktop read more at https://github.com/maxgallup/tailscale-status/blob/main/README.md",
   "name": "Tailscale Status",
   "settings-schema": "org.gnome.shell.extensions.tailscale-status",
-  "shell-version": ["45", "46", "47", "48", "49"],
+  "shell-version": ["45", "46", "47", "48", "49", "50"],
   "url": "https://github.com/maxgallup/tailscale-status",
   "uuid": "tailscale-status@maxgallup.github.com",
-  "version": 20
+  "version": 21
 }


### PR DESCRIPTION
## Summary
- Add GNOME Shell 50 to supported `shell-version` list in `metadata.json`
- Bump extension version from 20 to 21
- Remove unused `ExtensionUtils` import

Closes #71

## Test plan
- [x] Tested on GNOME 50 (Arch Linux) — extension loads, panel icon appears, menu opens, nodes list populates